### PR TITLE
Corrigindo label profissional 

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,7 +699,7 @@
               </div>
               <div class="info-text">
                 <h3><a href="https://www.linkedin.com/in/liviagabos/">Livia Gabos</a></h3>
-                <p>Consultora e Instrutura, Alura </p>
+                <p>Consultora e Instrutora, Alura </p>
               </div>
             </div>
             <!-- Team Item Ends -->


### PR DESCRIPTION
Conforme reportado na issue https://github.com/womendevsummit/womendevsummit.github.io/issues/1, há um erro na label profissional da Livia Goes, onde está "Instrutura" ao invés de "Instrutora". Sendo assim, este PR realiza essa correção.